### PR TITLE
fix: remove duplicate entries

### DIFF
--- a/2 - Early Contributors/final_early_contributor_amounts.json
+++ b/2 - Early Contributors/final_early_contributor_amounts.json
@@ -621,10 +621,6 @@
             "tokens": "602.01"
         },
         {
-            "address": "0xf56c68872e941c341025d9907d4821f9c8087166",
-            "tokens": "602.01"
-        },
-        {
             "address": "0xe3e02123a4126de661af887eee222498c6442ffc",
             "tokens": "602.01"
         },
@@ -674,10 +670,6 @@
         },
         {
             "address": "0x036f67fcc84eae8d0edba9aade6d8987cca48a4a",
-            "tokens": "602.01"
-        },
-        {
-            "address": "0x1fdcce71b0113195fd97e4073adbe82bb2689537",
             "tokens": "602.01"
         },
         {


### PR DESCRIPTION
addresses:

`0x1FdccE71b0113195fd97E4073aDBe82bb2689537`
`0xF56c68872e941C341025D9907D4821f9C8087166`

have duplicated entries, will cause issues when generating airdrop data for code claim site https://github.com/Developer-DAO/code-claim-site/pull/97